### PR TITLE
dev: create POO notebook

### DIFF
--- a/enclaveid/notebooks/EnclaveID.ipynb
+++ b/enclaveid/notebooks/EnclaveID.ipynb
@@ -1,0 +1,607 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "3fe3a2de-6e7c-4dba-b8e8-eb705b1e67ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded as API: https://huggingface-projects-llama-2-7b-chat.hf.space ✔\n",
+      "Loaded as API: https://hysts-mistral-7b.hf.space ✔\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gradio_client import Client\n",
+    "import json\n",
+    "import json_repair\n",
+    "from langchain import PromptTemplate\n",
+    "from langchain.chains import LLMChain\n",
+    "from langchain.chat_models import ChatOpenAI\n",
+    "\n",
+    "LLAMA2_7B_CLIENT = Client(\"huggingface-projects/llama-2-7b-chat\")\n",
+    "MISTRAL_7B_CLIENT = Client(\"hysts/mistral-7b\")\n",
+    "\n",
+    "\n",
+    "def ask_llama2_7b(prompt, \n",
+    "                  system_prompt=\"\",\n",
+    "                  max_new_tokens=1024, \n",
+    "                  temperature=0.6,\n",
+    "                  top_p=0.9,\n",
+    "                  top_k=50,\n",
+    "                  repetition_penalty=1.2):\n",
+    "    \"\"\"\n",
+    "    It generates a response using the Llama2 7B HuggingFace Space as API\n",
+    "    \"\"\"\n",
+    "    response = LLAMA2_7B_CLIENT.predict(\n",
+    "        prompt, system_prompt, max_new_tokens, temperature, top_p, top_k, repetition_penalty, api_name=\"/chat\" \n",
+    "    )\n",
+    "    return response\n",
+    "\n",
+    "\n",
+    "def ask_mistral_7b(\n",
+    "      prompt, \n",
+    "      max_new_tokens=1024, \n",
+    "      temperature=0.6,\n",
+    "      top_p=0.9,\n",
+    "      top_k=50,\n",
+    "      repetition_penalty=1.2):\n",
+    "    \"\"\"\n",
+    "    It generates a response using the Mistral 7B HuggingFace unofficial space as API\n",
+    "    \"\"\"\n",
+    "    response = MISTRAL_7B_CLIENT.predict(\n",
+    "        prompt, max_new_tokens, temperature, top_p, top_k, repetition_penalty, api_name=\"/chat\"\n",
+    "    )\n",
+    "    return response\n",
+    "\n",
+    "\n",
+    "def extract_json(gpt_answer):\n",
+    "    text = gpt_answer.replace(\"\\\\n\", \"\\n\")\n",
+    "    start_index = text.find(\"{\")\n",
+    "    end_index = text.rfind(\"}\")\n",
+    "\n",
+    "    json_text = text\n",
+    "    if start_index != -1 and end_index != -1 and start_index < end_index:\n",
+    "        json_text = text[start_index : end_index + 1]\n",
+    "\n",
+    "    json_response = json_repair.loads(json_text)\n",
+    "    return json_response    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae4e3fe7-f441-4027-b31d-b0181b646bd1",
+   "metadata": {},
+   "source": [
+    "## Generated generic markers using GPT4\n",
+    "\n",
+    "This data is expected to be generated only once. Not need to be dynamic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "d751ab2a-0abc-42c8-9f22-a298ed8845ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "markers = {\n",
+    "    \"openness\": {\n",
+    "        \"positive\": \"Searches and conversations about diverse topics, cultural interests, artistic activities, and philosophical discussions.\",\n",
+    "        \"negative\": \"Limited variety in search topics, avoidance of abstract or theoretical discussions in conversations.\"\n",
+    "    },\n",
+    "    \"conscientiousness\": {\n",
+    "        \"positive\": \"Searches related to planning, organization, and goal-setting. Conversations about personal achievements, detailed planning, and adherence to schedules.\",\n",
+    "        \"negative\": \"Disorganized or last-minute search patterns, conversations indicating procrastination or disinterest in planning.\"\n",
+    "    },\n",
+    "    \"extraversion\": {\n",
+    "        \"positive\": \"Online engagement with social events, searches about networking opportunities. Conversations that are energetic, involve many social topics, or planning social events.\",\n",
+    "        \"negative\": \"Limited searches about social activities, conversations that are short, infrequent, or reveal a preference for solitude.\"\n",
+    "    },\n",
+    "    \"agreeableness\": {\n",
+    "        \"positive\": \"Searches about volunteering, social causes, or how to help others. Conversations that are empathetic, understanding, and cooperative.\",\n",
+    "        \"negative\": \"Searches indicating conflict, hostility, or self-centered interests. Conversations that are argumentative, lack empathy, or are overly competitive.\"\n",
+    "    },\n",
+    "    \"neuroticism\": {\n",
+    "        \"positive\": \"Lack of excessive searches about worries, fears, or health anxieties. Balanced and calm nature in conversations.\",\n",
+    "        \"negative\": \"Frequent searches about health anxieties, fears, or negative outcomes. Conversations that are often worried, stressed, or pessimistic.\"\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0ed9425-bfb5-46b6-8a92-bda8d57a0006",
+   "metadata": {},
+   "source": [
+    "## Mocktest traits classification for a single chunk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8b95d7c6-ca75-4a2f-ace4-2c5ba5828b97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chunk_test_search_history = \"\"\"\n",
+    "7:26,Searched for how to stay motivated big corp reddit\n",
+    "7:27,Searched for site:news.ycombinator.com large company\n",
+    "7:27,Visited Think before you join any large company. Nothing here is unique to ...\n",
+    "7:28,Visited Why do giant companies do so many hilariously dumb things? As ...\n",
+    "7:29,Visited Ask HN: Startup acquired by a large company and it sucks. What to ...\n",
+    "7:30,\"Visited Ask HN: Moving from a startup to a big co, what should I be aware of ...\"\n",
+    "7:35,\"Visited Large company? Literally every company I ever worked for, the ...\"\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "f3bd0366-060e-4263-bf9d-dc0d96d6b333",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = f\"\"\"\n",
+    "Please analyze the given search history and classify the associated OCEAN personality traits \\\n",
+    "(Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism) based on predefined markers. \n",
+    "\n",
+    "Assign each trait a level: high, medium, low, or none.\n",
+    "\n",
+    "Search History:\n",
+    "{chunk_test_search_history}\n",
+    "\n",
+    "Markers for OCEAN Traits:\n",
+    "{markers}\n",
+    "\n",
+    "Your task is to evaluate the search history against these markers and classify the level of each \\\n",
+    "OCEAN trait. \n",
+    "\n",
+    "Format your response as a JSON object, using the trait names as keys and the assigned levels as values. \n",
+    "\n",
+    "Expected JSON Output Format:\n",
+    "{{\n",
+    "    \"openness\": \"high/medium/low/none\",\n",
+    "    \"conscientiousness\": \"high/medium/low/none\",\n",
+    "    \"extraversion\": \"high/medium/low/none\",\n",
+    "    \"agreeableness\": \"high/medium/low/none\",\n",
+    "    \"neuroticism\": \"high/medium/low/none\"\n",
+    "}}\n",
+    "\n",
+    "Note:\n",
+    "- Replace \"high/medium/low/none\" with the appropriate level based on your analysis.\n",
+    "- Ensure that the response strictly adheres to the JSON format specified.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "1021ab8a-530b-4899-bae8-a11d335baa60",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'openness': 'None',\n",
+       " 'conscientiousness': 'None',\n",
+       " 'extraversion': 'None',\n",
+       " 'agreeableness': 'None',\n",
+       " 'neuroticism': 'None'}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response = ask_mistral_7b(prompt=prompt)\n",
+    "response = extract_json(response)\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ef2a79e3-acd7-4f4a-87d4-643914a4c796",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'openness': 'medium',\n",
+       " 'conscientiousness': 'medium',\n",
+       " 'extraversion': 'high',\n",
+       " 'agreeableness': 'high',\n",
+       " 'neuroticism': 'low'}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response = ask_llama2_7b(prompt=prompt)\n",
+    "response = extract_json(response)\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aad050fb-dd3e-4fc8-826b-3665efa3759a",
+   "metadata": {},
+   "source": [
+    "## Classify mocked data \n",
+    "\n",
+    "This is done by using a non-openAI based model\n",
+    "\n",
+    "**Note: Models from HuggingFace can be shutted down at any time**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "d446476a-bb24-4078-8e4d-09d4ea5be43e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mocked_data_chunks = [\n",
+    "\"\"\"\n",
+    "7:26,Searched for how to stay motivated big corp reddit\n",
+    "7:27,Searched for site:news.ycombinator.com large company\n",
+    "7:27,Visited Think before you join any large company. Nothing here is unique to ...\n",
+    "7:28,Visited Why do giant companies do so many hilariously dumb things? As ...\n",
+    "7:29,Visited Ask HN: Startup acquired by a large company and it sucks. What to ...\n",
+    "7:30,\"Visited Ask HN: Moving from a startup to a big co, what should I be aware of ...\"\n",
+    "7:35,\"Visited Large company? Literally every company I ever worked for, the ...\"\n",
+    "\"\"\",\n",
+    "# high agreeableness and high neuroticism\n",
+    "\"\"\"\n",
+    "8:15, Searched for local charity events near me\n",
+    "8:17, Searched for how to deal with feeling overwhelmed at work\n",
+    "8:19, Visited forum post on tips for better understanding others' feelings\n",
+    "8:20, Read article on managing anxiety and stress in personal relationships\n",
+    "8:23, Searched for ways to help a friend in need\n",
+    "8:25, Visited blog on coping with fears of failure and rejection\n",
+    "\"\"\",\n",
+    "# high agreeableness and high neuroticism\n",
+    "\"\"\"\n",
+    "9:10, Searched for how to volunteer for local homeless shelters\n",
+    "9:12, Searched for articles on overcoming personal insecurities\n",
+    "9:14, Visited a page on empathetic communication skills\n",
+    "9:16, Read about techniques for managing social anxiety\n",
+    "9:18, Searched for upcoming community service events\n",
+    "9:20, Visited a support group forum for dealing with chronic worry\n",
+    "\"\"\",\n",
+    "# high consicientiousness, low everything else\n",
+    "\"\"\"\n",
+    "10:05, Searched for best time management tools for professionals\n",
+    "10:07, Searched for efficient filing systems for office use\n",
+    "10:09, Visited article on optimizing daily routines for productivity\n",
+    "10:11, Read tips on maintaining focus in a busy work environment\n",
+    "10:14, Searched for courses on advanced project management techniques\n",
+    "10:17, Visited blog on personal discipline and self-improvement in the workplace\n",
+    "\"\"\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "f9cd78b1-e577-492e-9c62-48176d3b37cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labeled_data = {}\n",
+    "for idx, chunk in enumerate(mocked_data_chunks):\n",
+    "    # update prompt\n",
+    "    prompt = f\"\"\"\n",
+    "    Please analyze the given search history and classify the associated OCEAN personality traits \\\n",
+    "    (Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism) based on predefined markers. \n",
+    "    \n",
+    "    Assign each trait a level: high, medium, low, or none.\n",
+    "    \n",
+    "    Search History:\n",
+    "    {chunk}\n",
+    "    \n",
+    "    Markers for OCEAN Traits:\n",
+    "    {markers}\n",
+    "    \n",
+    "    Your task is to evaluate the search history against these markers and classify the level of each \\\n",
+    "    OCEAN trait. \n",
+    "    \n",
+    "    Format your response as a JSON object, using the trait names as keys and the assigned levels as values. \n",
+    "    \n",
+    "    Expected JSON Output Format:\n",
+    "    {{\n",
+    "        \"openness\": \"high/medium/low/none\",\n",
+    "        \"conscientiousness\": \"high/medium/low/none\",\n",
+    "        \"extraversion\": \"high/medium/low/none\",\n",
+    "        \"agreeableness\": \"high/medium/low/none\",\n",
+    "        \"neuroticism\": \"high/medium/low/none\"\n",
+    "    }}\n",
+    "    \n",
+    "    Note:\n",
+    "    - Replace \"high/medium/low/none\" with the appropriate level based on your analysis.\n",
+    "    - Ensure that the response strictly adheres to the JSON format specified.\n",
+    "    \"\"\"\n",
+    "    response = ask_llama2_7b(prompt=prompt)\n",
+    "    response = extract_json(response)\n",
+    "    labeled_data[idx] = response    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "5778a724-5620-4671-9911-2e20801951f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{0: {'openness': 'high',\n",
+       "  'conscientiousness': 'medium',\n",
+       "  'extraversion': 'medium',\n",
+       "  'agreeableness': 'medium',\n",
+       "  'neuroticism': 'low'},\n",
+       " 1: {'openness': 'high',\n",
+       "  'conscientiousness': 'medium',\n",
+       "  'extraversion': 'medium',\n",
+       "  'agreeableness': 'medium',\n",
+       "  'neuroticism': 'low'},\n",
+       " 2: {'openness': 'high',\n",
+       "  'conscientiousness': 'medium',\n",
+       "  'extraversion': 'medium',\n",
+       "  'agreeableness': 'medium',\n",
+       "  'neuroticism': 'low'},\n",
+       " 3: {'openness': 'high',\n",
+       "  'conscientiousness': 'medium',\n",
+       "  'extraversion': 'medium',\n",
+       "  'agreeableness': 'medium',\n",
+       "  'neuroticism': 'low'}}"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labeled_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be22dc4f-e70b-4ebd-8919-a5aedf31f255",
+   "metadata": {},
+   "source": [
+    "## Score according mocked data\n",
+    "\n",
+    "In the case of search history, we want to score only **openness, neuroticism, and conscientiousness**. We want to do that using only the chunks where the trait was labeled as high"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "20364beb-4ada-40c8-b6a7-523c0b6ea0eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_chunks(labeled_data, selected_traits):\n",
+    "    chunks = {}\n",
+    "    # prepare dict \n",
+    "    for selected_trait in selected_traits:\n",
+    "        chunks[selected_trait] = []\n",
+    "\n",
+    "    # fill dict\n",
+    "    for idx, traits in labeled_data.items():\n",
+    "        for selected_trait in selected_traits:\n",
+    "            if traits[selected_trait] == \"high\":\n",
+    "                chunks[selected_trait].append(mocked_data_chunks[idx])\n",
+    "    return chunks "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "481130f9-e5de-479c-b579-17e6c55beaf7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'openness': [],\n",
+       " 'neuroticism': [\"\\n8:15, Searched for local charity events near me\\n8:17, Searched for how to deal with feeling overwhelmed at work\\n8:19, Visited forum post on tips for better understanding others' feelings\\n8:20, Read article on managing anxiety and stress in personal relationships\\n8:23, Searched for ways to help a friend in need\\n8:25, Visited blog on coping with fears of failure and rejection\\n\",\n",
+       "  '\\n9:10, Searched for how to volunteer for local homeless shelters\\n9:12, Searched for articles on overcoming personal insecurities\\n9:14, Visited a page on empathetic communication skills\\n9:16, Read about techniques for managing social anxiety\\n9:18, Searched for upcoming community service events\\n9:20, Visited a support group forum for dealing with chronic worry\\n'],\n",
+       " 'conscientiousness': ['\\n10:05, Searched for best time management tools for professionals\\n10:07, Searched for efficient filing systems for office use\\n10:09, Visited article on optimizing daily routines for productivity\\n10:11, Read tips on maintaining focus in a busy work environment\\n10:14, Searched for courses on advanced project management techniques\\n10:17, Visited blog on personal discipline and self-improvement in the workplace\\n']}"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "selected_traits = [\"openness\", \"neuroticism\", \"conscientiousness\"]\n",
+    "labeled_data = {\n",
+    "    0: {\n",
+    "        \"openness\": \"medium\",\n",
+    "        \"conscientiousness\": \"medium\",\n",
+    "        \"extraversion\": \"low\",\n",
+    "        \"agreeableness\": \"low\",\n",
+    "        \"neuroticism\": \"medium\"\n",
+    "    },\n",
+    "    1: {\n",
+    "        \"openness\": \"medium\",\n",
+    "        \"conscientiousness\": \"medium\",\n",
+    "        \"extraversion\": \"low\",\n",
+    "        \"agreeableness\": \"high\",\n",
+    "        \"neuroticism\": \"high\"\n",
+    "    },\n",
+    "    2: {\n",
+    "        \"openness\": \"medium\",\n",
+    "        \"conscientiousness\": \"medium\",\n",
+    "        \"extraversion\": \"low\",\n",
+    "        \"agreeableness\": \"high\",\n",
+    "        \"neuroticism\": \"high\"\n",
+    "    },\n",
+    "    3: {\n",
+    "        \"openness\": \"low\",\n",
+    "        \"conscientiousness\": \"high\",\n",
+    "        \"extraversion\": \"low\",\n",
+    "        \"agreeableness\": \"none\",\n",
+    "        \"neuroticism\": \"low\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "# Obtain a list of chunks per trait.\n",
+    "selected_chunks = get_chunks(labeled_data, selected_traits)\n",
+    "selected_chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "87874f3f-e500-40fc-911f-9f9c3825cb2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['OPENAI_API_KEY'] = \"\"\n",
+    "\n",
+    "\n",
+    "SCORE_TEMPLATE = \"\"\"\n",
+    "Please assign a score between 0.0 and 1.0 to represent the level of the trait {trait} in the following text. \n",
+    "A score of 0 indicates the complete absence of the trait, while a score of 1 indicates the highest expression of the trait.\n",
+    "\n",
+    "Output your answer as a single number without giving any explanation.\n",
+    "\n",
+    "Text: {chunk}\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "score_prompt = PromptTemplate(\n",
+    "    input_variables=[\"trait\", \"chunk\"],\n",
+    "    template=SCORE_TEMPLATE,\n",
+    ")\n",
+    "\n",
+    "chain = LLMChain(\n",
+    "    llm=ChatOpenAI(model_name=\"gpt-3.5-turbo\"),\n",
+    "    prompt=score_prompt\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def score_trait(selected_chunks): \n",
+    "    \"\"\"\n",
+    "    If a trait does not have chunks (because none of them were labeled as high) we score the trait with a 0.\n",
+    "    Otherwise, we score the trait with the average score of its chunks.\n",
+    "    \"\"\"\n",
+    "    scored_traits = {}\n",
+    "    for trait, chunks in selected_chunks.items():\n",
+    "        scores = []\n",
+    "        if not chunks: \n",
+    "            score = 0\n",
+    "        else: \n",
+    "            for chunk in chunks:\n",
+    "                score_instance = float(chain.run({\"trait\": trait, \"chunk\": chunk}))\n",
+    "                scores.append(score_instance)\n",
+    "                score = sum(scores)/len(scores) \n",
+    "        scored_traits[trait] = {\n",
+    "            \"n_chunks\": len(chunks),\n",
+    "            \"scores\": scores,\n",
+    "            \"average_score\": score\n",
+    "        }\n",
+    "    return scored_traits "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "cf0b7f6c-c0d8-42e0-8e15-de2a6f3e78b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "score_output = score_trait(selected_chunks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "398e3865-7650-4592-a121-adee4953d059",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'openness': {'n_chunks': 0, 'scores': [], 'average_score': 0},\n",
+       " 'neuroticism': {'n_chunks': 2, 'scores': [0.8, 0.6], 'average_score': 0.7},\n",
+       " 'conscientiousness': {'n_chunks': 1, 'scores': [0.8], 'average_score': 0.8}}"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "score_output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "6f8f3435-5d06-4080-afe1-0f9180cfa975",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The trait:\u001b[1m openness \u001b[0m has a score of: \u001b[1m0\u001b[0m\n",
+      "The trait:\u001b[1m neuroticism \u001b[0m has a score of: \u001b[1m0.7\u001b[0m\n",
+      "The trait:\u001b[1m conscientiousness \u001b[0m has a score of: \u001b[1m0.8\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "for trait, result in score_output.items():\n",
+    "    print(f\"The trait:\\033[1m {trait} \\033[0m has a score of: \\033[1m{result['average_score']}\\033[0m\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "946c73cf-5f68-4ba1-a964-0f27dfbf2e86",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR introduces an initial notebook that establishes a proof-of-concept workflow, intended to serve as a reference for a baseline implementation.

- Initially, we pre-define positive and negative trait markers, and store them in a JSON/dictionary format as fixed data.
- Next, we apply these markers to classify segments of data (note: the segmentation of the data is not yet implemented at this moment) using a model that is not based on OpenAI (e.g., Llama2_7b).
- Subsequently, for each trait, we retrieve the data segments that were labeled as `high`, which means a high correspondence to the trait. 
- Lastly, we evaluate each segment of data related to a specific trait, using GPT to assign a score ranging from 0 to 1. The final score is the average score of all the data segments. 


Note: The code in the notebook is quick testing code, so the code quality is not superb and there are still some things to fix. Also, data segments/chunks are mocked, as well as the search history input 